### PR TITLE
Jude d bills refactoring and copy all emails functionality in Committees

### DIFF
--- a/src/components/BreadcrumbsNav.tsx
+++ b/src/components/BreadcrumbsNav.tsx
@@ -1,0 +1,7 @@
+import { Breadcrumbs, type BreadcrumbsProps } from "@mui/material";
+
+const BreadcrumbsNav = (props: BreadcrumbsProps) => (
+  <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 1 }} {...props} />
+);
+
+export default BreadcrumbsNav;

--- a/src/pages/extra-pages/BillDetailPage.tsx
+++ b/src/pages/extra-pages/BillDetailPage.tsx
@@ -1,12 +1,11 @@
 import {
-  ExpandAltOutlined,
-  HomeOutlined,
   ReloadOutlined,
-  SearchOutlined
+  SearchOutlined,
+  ExpandAltOutlined,
+  LeftOutlined
 } from "@ant-design/icons";
 import {
   Box,
-  Breadcrumbs,
   IconButton,
   InputAdornment,
   Link,
@@ -23,13 +22,12 @@ import {
   useGridApiRef
 } from "@mui/x-data-grid";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { NavLink, useNavigate, useSearchParams } from "react-router-dom";
-import type { BillRow } from "../../api/bill";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { LegislatureService } from "../../api/legislatureService";
+import type { BillRow } from "../../api/bill";
+import BreadcrumbsNav from "../../components/BreadcrumbsNav";
 import {
-  extractBillNumber,
-  mapLegislativeDocumentToBillRow,
-  summarizeSponsors
+  BillsService
 } from "../../utils/bills";
 
 const DEFAULT_DOCUMENT_CLASS = "Bills";
@@ -130,9 +128,8 @@ const BillDetailPage = () => {
     LegislatureService.getInstance()
       .getBills(DEFAULT_DOCUMENT_CLASS)
       .then((response) => {
-        const docs = Array.isArray(response) ? response : [];
-        const match = docs.find((doc) => {
-          const normalized = extractBillNumber(doc?.Name ?? "", doc);
+        const match = response.find((doc) => {
+          const normalized = BillsService.extractBillNumber(doc?.Name ?? "", doc);
           if (targetNumber && normalized === targetNumber) {
             return true;
           }
@@ -142,11 +139,11 @@ const BillDetailPage = () => {
           return false;
         });
         if (match) {
-          const row = mapLegislativeDocumentToBillRow(match, 0);
+          const row = BillsService.mapLegislativeDocumentToBillRow(match, 0);
           if (row) {
             setBill({
               ...row,
-              sponsors: summarizeSponsors(match)
+              sponsors: BillsService.summarizeSponsors(match)
             });
           } else {
             setBill(null);
@@ -177,12 +174,18 @@ const BillDetailPage = () => {
   }, [bill]);
 
   return (
-    <>
-      <Breadcrumbs aria-label="breadcrumb">
-        <NavLink to="/" ><IconButton size="medium"><HomeOutlined /></IconButton></NavLink>
-        <NavLink to="/bills" >Bills</NavLink>
-        <Typography color="text.primary">Bill Detail</Typography>
-      </Breadcrumbs>
+    <Box sx={{ marginTop: 1 }}>
+      <BreadcrumbsNav>
+        <Link
+          component="button"
+          underline="hover"
+          color="inherit"
+          onClick={() => navigate("/bills")}
+        >
+          <LeftOutlined style={{ fontSize: 12, marginRight: 6 }} />
+          Back to Bills
+        </Link>
+      </BreadcrumbsNav>
       <Toolbar sx={{ justifyContent: "space-between" }}>
         <Box>
           <Typography variant="h3" component="div">
@@ -239,7 +242,7 @@ const BillDetailPage = () => {
         disableRowSelectionOnClick
         hideFooter
       />
-    </>
+    </Box>
   );
 };
 

--- a/src/pages/extra-pages/BillDetailPage.tsx
+++ b/src/pages/extra-pages/BillDetailPage.tsx
@@ -6,7 +6,6 @@ import {
 } from "@ant-design/icons";
 import {
   Box,
-  Breadcrumbs,
   IconButton,
   InputAdornment,
   Link,
@@ -26,10 +25,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { LegislatureService } from "../../api/legislatureService";
 import type { BillRow } from "../../api/bill";
+import BreadcrumbsNav from "../../components/BreadcrumbsNav";
 import {
-  extractBillNumber,
-  mapLegislativeDocumentToBillRow,
-  summarizeSponsors
+  BillsService
 } from "../../utils/bills";
 
 const DEFAULT_DOCUMENT_CLASS = "Bills";
@@ -130,9 +128,8 @@ const BillDetailPage = () => {
     LegislatureService.getInstance()
       .getBills(DEFAULT_DOCUMENT_CLASS)
       .then((response) => {
-        const docs = Array.isArray(response) ? response : [];
-        const match = docs.find((doc) => {
-          const normalized = extractBillNumber(doc?.Name ?? "", doc);
+        const match = response.find((doc) => {
+          const normalized = BillsService.extractBillNumber(doc?.Name ?? "", doc);
           if (targetNumber && normalized === targetNumber) {
             return true;
           }
@@ -142,11 +139,11 @@ const BillDetailPage = () => {
           return false;
         });
         if (match) {
-          const row = mapLegislativeDocumentToBillRow(match, 0);
+          const row = BillsService.mapLegislativeDocumentToBillRow(match, 0);
           if (row) {
             setBill({
               ...row,
-              sponsors: summarizeSponsors(match)
+              sponsors: BillsService.summarizeSponsors(match)
             });
           } else {
             setBill(null);
@@ -178,7 +175,7 @@ const BillDetailPage = () => {
 
   return (
     <Box sx={{ marginTop: 1 }}>
-      <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 1 }}>
+      <BreadcrumbsNav>
         <Link
           component="button"
           underline="hover"
@@ -188,7 +185,7 @@ const BillDetailPage = () => {
           <LeftOutlined style={{ fontSize: 12, marginRight: 6 }} />
           Back to Bills
         </Link>
-      </Breadcrumbs>
+      </BreadcrumbsNav>
       <Toolbar sx={{ justifyContent: "space-between" }}>
         <Box>
           <Typography variant="h3" component="div">

--- a/src/pages/extra-pages/BillsPage.tsx
+++ b/src/pages/extra-pages/BillsPage.tsx
@@ -8,8 +8,8 @@ import {
   IconButton,
   InputAdornment,
   Link,
-  Tab,
-  Tabs,
+  ToggleButton,
+  ToggleButtonGroup,
   TextField,
   Toolbar,
   Tooltip,
@@ -19,13 +19,14 @@ import {
   DataGrid,
   GridColDef,
   type GridPaginationModel,
+  GridToolbarContainer,
   useGridApiRef
 } from "@mui/x-data-grid";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { LegislatureService } from "../../api/legislatureService";
 import type { BillRow, LegislativeDocument } from "../../api/bill";
-import { mapLegislativeDocumentToBillRow, sanitizeBillUrl } from "../../utils/bills";
+import { BillsService } from "../../utils/bills";
 
 const DEFAULT_DOCUMENT_CLASS = "Bills";
 const BILL_SEARCH_URL = "https://app.leg.wa.gov/billsearch/";
@@ -39,6 +40,13 @@ const tabs = [
 ] as const;
 
 type TabValue = (typeof tabs)[number]["value"];
+
+type BillsToolbarProps = {
+  search: string;
+  onSearchChange: (value: string) => void;
+  onOpenSearch: () => void;
+  onRefresh: () => void;
+};
 
 const columns: GridColDef<BillRow>[] = [
   {
@@ -122,7 +130,7 @@ const BillsPage = () => {
             doc.Hyperlink ??
             doc.SourceUrl ??
             "";
-          const sanitizedUrl = sanitizeBillUrl(rawUrl, doc);
+          const sanitizedUrl = BillsService.sanitizeBillUrl(rawUrl, doc);
           console.log("Fetched bill document URL:", sanitizedUrl);
         });
         setRawBills(docs);
@@ -146,38 +154,31 @@ const BillsPage = () => {
 
   const rows = useMemo<BillRow[]>(() => {
     return rawBills
-      .map((bill, index) => mapLegislativeDocumentToBillRow(bill, index))
+      .map((bill, index) => BillsService.mapLegislativeDocumentToBillRow(bill, index))
       .filter(Boolean) as BillRow[];
   }, [rawBills]);
 
-  const filteredRows = useMemo(() => {
-    const loweredQuery = search.trim().toLowerCase();
-    return rows.filter((row) => {
-      const matchesTab =
-        tab === "all" ? true : row.chamber.toLowerCase() === tab;
+  const filterPredicate = useMemo(() => {
+    return BillsService.buildFilterPredicate({ tab, query: search });
+  }, [tab, search]);
 
-      if (!matchesTab) {
-        return false;
-      }
+  const filteredRows = useMemo(() => rows.filter(filterPredicate), [rows, filterPredicate]);
 
-      if (!loweredQuery) {
-        return true;
-      }
+  const handleRowDoubleClick = useCallback((row: BillRow) => {
+    const targetBill =
+      row?.normalizedBillNumber ||
+      row?.billNumber?.replace(/\D+/g, "") ||
+      "";
+    const rawName = row?.raw?.Name ?? "";
+    if (!targetBill) {
+      return;
+    }
+    navigate(`/bill?number=${encodeURIComponent(targetBill)}&name=${encodeURIComponent(rawName)}`);
+  }, [navigate]);
 
-      const haystack = [
-        row.billNumber,
-        row.title,
-        row.committee,
-        row.status,
-        row.history,
-        row.latestDocumentLabel
-      ]
-        .join(" ")
-        .toLowerCase();
-
-      return haystack.includes(loweredQuery);
-    });
-  }, [rows, tab, search]);
+  const handleOpenBillSearch = useCallback(() => {
+    window.open(BILL_SEARCH_URL, "_blank", "noopener");
+  }, []);
 
   return (
     <Box sx={{ marginTop: 1 }}>
@@ -185,44 +186,28 @@ const BillsPage = () => {
         <Typography variant="h3" component="div" sx={{ flexGrow: 1 }}>
           Bills
         </Typography>
-        <TextField
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-          size="small"
-          placeholder="Search"
-          sx={{ width: 220, mr: 1.5 }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchOutlined />
-              </InputAdornment>
-            )
-          }}
-        />
-        <Tooltip title="Open Bill Search">
-          <IconButton
-            color="primary"
-            onClick={() => window.open(BILL_SEARCH_URL, "_blank", "noopener")}
-          >
-            <ExpandAltOutlined />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Refresh">
-          <IconButton color="primary" onClick={fetchBills}>
-            <ReloadOutlined />
-          </IconButton>
-        </Tooltip>
       </Toolbar>
-      <Tabs
+      <ToggleButtonGroup
         value={tab}
-        onChange={(_event, value: TabValue) => setTab(value)}
+        exclusive
+        onChange={(_event, value: TabValue | null) => {
+          if (value) {
+            setTab(value);
+          }
+        }}
         aria-label="bill chamber filter"
         sx={{ mb: 2 }}
       >
         {tabs.map((tabOption) => (
-          <Tab key={tabOption.value} label={tabOption.label} value={tabOption.value} />
+          <ToggleButton
+            key={tabOption.value}
+            value={tabOption.value}
+            aria-label={tabOption.label}
+          >
+            {tabOption.label}
+          </ToggleButton>
         ))}
-      </Tabs>
+      </ToggleButtonGroup>
       <DataGrid
         apiRef={apiRef}
         autoHeight
@@ -234,21 +219,52 @@ const BillsPage = () => {
         onPaginationModelChange={setPaginationModel}
         pageSizeOptions={[10, 25, 50, 100]}
         disableRowSelectionOnClick
-        onRowDoubleClick={(params) => {
-          const row = params.row as BillRow;
-          const targetBill =
-            row?.normalizedBillNumber ||
-            row?.billNumber?.replace(/\D+/g, "") ||
-            "";
-          const rawName = row?.raw?.Name ?? "";
-          if (!targetBill) {
-            return;
-          }
-          navigate(`/bill?number=${encodeURIComponent(targetBill)}&name=${encodeURIComponent(rawName)}`);
+        onRowDoubleClick={(params) => handleRowDoubleClick(params.row as BillRow)}
+        slots={{ toolbar: BillsToolbar }}
+        slotProps={{
+          toolbar: {
+            search,
+            onSearchChange: setSearch,
+            onOpenSearch: handleOpenBillSearch,
+            onRefresh: fetchBills
+          } satisfies BillsToolbarProps
         }}
       />
     </Box>
   );
 };
+
+function BillsToolbar(props: BillsToolbarProps) {
+  const { search, onSearchChange, onOpenSearch, onRefresh } = props;
+
+  return (
+    <GridToolbarContainer sx={{ justifyContent: "flex-end", gap: 1, p: 1 }}>
+      <TextField
+        value={search}
+        onChange={(event) => onSearchChange(event.target.value)}
+        size="small"
+        placeholder="Search"
+        sx={{ width: 220 }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchOutlined />
+            </InputAdornment>
+          )
+        }}
+      />
+      <Tooltip title="Open Bill Search">
+        <IconButton color="primary" onClick={onOpenSearch}>
+          <ExpandAltOutlined />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Refresh">
+        <IconButton color="primary" onClick={onRefresh}>
+          <ReloadOutlined />
+        </IconButton>
+      </Tooltip>
+    </GridToolbarContainer>
+  );
+}
 
 export default BillsPage;

--- a/src/pages/extra-pages/BillsPage.tsx
+++ b/src/pages/extra-pages/BillsPage.tsx
@@ -19,7 +19,6 @@ import {
   DataGrid,
   GridColDef,
   type GridPaginationModel,
-  GridToolbarContainer,
   useGridApiRef
 } from "@mui/x-data-grid";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -40,13 +39,6 @@ const tabs = [
 ] as const;
 
 type TabValue = (typeof tabs)[number]["value"];
-
-type BillsToolbarProps = {
-  search: string;
-  onSearchChange: (value: string) => void;
-  onOpenSearch: () => void;
-  onRefresh: () => void;
-};
 
 const columns: GridColDef<BillRow>[] = [
   {
@@ -180,13 +172,8 @@ const BillsPage = () => {
     window.open(BILL_SEARCH_URL, "_blank", "noopener");
   }, []);
 
-  return (
-    <Box sx={{ marginTop: 1 }}>
-      <Toolbar>
-        <Typography variant="h3" component="div" sx={{ flexGrow: 1 }}>
-          Bills
-        </Typography>
-      </Toolbar>
+  const BillsToolbar = () => (
+    <Toolbar sx={{ justifyContent: "space-between", gap: 2, p: 1 }}>
       <ToggleButtonGroup
         value={tab}
         exclusive
@@ -196,7 +183,6 @@ const BillsPage = () => {
           }
         }}
         aria-label="bill chamber filter"
-        sx={{ mb: 2 }}
       >
         {tabs.map((tabOption) => (
           <ToggleButton
@@ -208,6 +194,42 @@ const BillsPage = () => {
           </ToggleButton>
         ))}
       </ToggleButtonGroup>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <TextField
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          size="small"
+          placeholder="Search"
+          sx={{ width: 220 }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchOutlined />
+              </InputAdornment>
+            )
+          }}
+        />
+        <Tooltip title="Open Bill Search">
+          <IconButton color="primary" onClick={handleOpenBillSearch}>
+            <ExpandAltOutlined />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Refresh">
+          <IconButton color="primary" onClick={fetchBills}>
+            <ReloadOutlined />
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </Toolbar>
+  );
+
+  return (
+    <Box sx={{ marginTop: 1 }}>
+      <Toolbar>
+        <Typography variant="h3" component="div" sx={{ flexGrow: 1 }}>
+          Bills
+        </Typography>
+      </Toolbar>
       <DataGrid
         apiRef={apiRef}
         autoHeight
@@ -221,50 +243,9 @@ const BillsPage = () => {
         disableRowSelectionOnClick
         onRowDoubleClick={(params) => handleRowDoubleClick(params.row as BillRow)}
         slots={{ toolbar: BillsToolbar }}
-        slotProps={{
-          toolbar: {
-            search,
-            onSearchChange: setSearch,
-            onOpenSearch: handleOpenBillSearch,
-            onRefresh: fetchBills
-          } satisfies BillsToolbarProps
-        }}
       />
     </Box>
   );
 };
-
-function BillsToolbar(props: BillsToolbarProps) {
-  const { search, onSearchChange, onOpenSearch, onRefresh } = props;
-
-  return (
-    <GridToolbarContainer sx={{ justifyContent: "flex-end", gap: 1, p: 1 }}>
-      <TextField
-        value={search}
-        onChange={(event) => onSearchChange(event.target.value)}
-        size="small"
-        placeholder="Search"
-        sx={{ width: 220 }}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <SearchOutlined />
-            </InputAdornment>
-          )
-        }}
-      />
-      <Tooltip title="Open Bill Search">
-        <IconButton color="primary" onClick={onOpenSearch}>
-          <ExpandAltOutlined />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title="Refresh">
-        <IconButton color="primary" onClick={onRefresh}>
-          <ReloadOutlined />
-        </IconButton>
-      </Tooltip>
-    </GridToolbarContainer>
-  );
-}
 
 export default BillsPage;

--- a/src/pages/extra-pages/BillsPage.tsx
+++ b/src/pages/extra-pages/BillsPage.tsx
@@ -1,20 +1,15 @@
 import {
-  ExpandAltOutlined,
-  HomeOutlined,
   ReloadOutlined,
-  SearchOutlined
+  SearchOutlined,
+  ExpandAltOutlined
 } from "@ant-design/icons";
 import {
   Box,
-  Breadcrumbs,
-  Card,
-  CardContent,
-  CardHeader,
   IconButton,
   InputAdornment,
   Link,
-  Tab,
-  Tabs,
+  ToggleButton,
+  ToggleButtonGroup,
   TextField,
   Toolbar,
   Tooltip,
@@ -23,13 +18,14 @@ import {
 import {
   DataGrid,
   GridColDef,
-  type GridPaginationModel
+  type GridPaginationModel,
+  useGridApiRef
 } from "@mui/x-data-grid";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { NavLink, useNavigate } from "react-router-dom";
-import type { BillRow, LegislativeDocument } from "../../api/bill";
+import { useNavigate } from "react-router-dom";
 import { LegislatureService } from "../../api/legislatureService";
-import { mapLegislativeDocumentToBillRow, sanitizeBillUrl } from "../../utils/bills";
+import type { BillRow, LegislativeDocument } from "../../api/bill";
+import { BillsService } from "../../utils/bills";
 
 const DEFAULT_DOCUMENT_CLASS = "Bills";
 const BILL_SEARCH_URL = "https://app.leg.wa.gov/billsearch/";
@@ -103,6 +99,7 @@ const columns: GridColDef<BillRow>[] = [
 ];
 
 const BillsPage = () => {
+  const apiRef = useGridApiRef();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [tab, setTab] = useState<TabValue>("all");
@@ -125,7 +122,7 @@ const BillsPage = () => {
             doc.Hyperlink ??
             doc.SourceUrl ??
             "";
-          const sanitizedUrl = sanitizeBillUrl(rawUrl, doc);
+          const sanitizedUrl = BillsService.sanitizeBillUrl(rawUrl, doc);
           console.log("Fetched bill document URL:", sanitizedUrl);
         });
         setRawBills(docs);
@@ -149,120 +146,105 @@ const BillsPage = () => {
 
   const rows = useMemo<BillRow[]>(() => {
     return rawBills
-      .map((bill, index) => mapLegislativeDocumentToBillRow(bill, index))
+      .map((bill, index) => BillsService.mapLegislativeDocumentToBillRow(bill, index))
       .filter(Boolean) as BillRow[];
   }, [rawBills]);
 
-  const filteredRows = useMemo(() => {
-    const loweredQuery = search.trim().toLowerCase();
-    return rows.filter((row) => {
-      const matchesTab =
-        tab === "all" ? true : row.chamber.toLowerCase() === tab;
+  const filterPredicate = useMemo(() => {
+    return BillsService.buildFilterPredicate({ tab, query: search });
+  }, [tab, search]);
 
-      if (!matchesTab) {
-        return false;
-      }
+  const filteredRows = useMemo(() => rows.filter(filterPredicate), [rows, filterPredicate]);
 
-      if (!loweredQuery) {
-        return true;
-      }
+  const handleRowDoubleClick = useCallback((row: BillRow) => {
+    const targetBill =
+      row?.normalizedBillNumber ||
+      row?.billNumber?.replace(/\D+/g, "") ||
+      "";
+    const rawName = row?.raw?.Name ?? "";
+    if (!targetBill) {
+      return;
+    }
+    navigate(`/bill?number=${encodeURIComponent(targetBill)}&name=${encodeURIComponent(rawName)}`);
+  }, [navigate]);
 
-      const haystack = [
-        row.billNumber,
-        row.title,
-        row.committee,
-        row.status,
-        row.history,
-        row.latestDocumentLabel
-      ]
-        .join(" ")
-        .toLowerCase();
+  const handleOpenBillSearch = useCallback(() => {
+    window.open(BILL_SEARCH_URL, "_blank", "noopener");
+  }, []);
 
-      return haystack.includes(loweredQuery);
-    });
-  }, [rows, tab, search]);
-
-  function CustomToolbar() {
-    return (<Toolbar>
-      <Box sx={{ marginTop: 1, flexGrow: 1 }}>
-        <Tabs
-          value={tab}
-          onChange={(_event, value: TabValue) => setTab(value)}
-          aria-label="bill chamber filter"
-          sx={{ mb: 2 }}
-        >
-          {tabs.map((tabOption) => (
-            <Tab key={tabOption.value} label={tabOption.label} value={tabOption.value} />
-          ))}
-        </Tabs>
-      </Box>
-      <TextField
-        value={search}
-        onChange={(event) => setSearch(event.target.value)}
-        size="small"
-        placeholder="Search"
-        sx={{ width: 220, mr: 1.5 }}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <SearchOutlined />
-            </InputAdornment>
-          )
+  const BillsToolbar = () => (
+    <Toolbar sx={{ justifyContent: "space-between", gap: 2, p: 1 }}>
+      <ToggleButtonGroup
+        value={tab}
+        exclusive
+        onChange={(_event, value: TabValue | null) => {
+          if (value) {
+            setTab(value);
+          }
         }}
-      />
-      <Tooltip title="Open Bill Search">
-        <IconButton
-          color="primary"
-          onClick={() => window.open(BILL_SEARCH_URL, "_blank", "noopener")}
-        >
-          <ExpandAltOutlined />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title="Refresh">
-        <IconButton color="primary" size="small" onClick={fetchBills}>
-          <ReloadOutlined />
-        </IconButton>
-      </Tooltip>
-    </Toolbar>
-    );
-  }
-
-  return (<>
-    <Breadcrumbs aria-label="breadcrumb">
-      <NavLink to="/" ><IconButton size="medium"><HomeOutlined /></IconButton></NavLink>
-      <Typography color="text.primary">Bills</Typography>
-    </Breadcrumbs>
-    <Card>
-      <CardHeader title="Bills" />
-      <CardContent>
-        <DataGrid
-          autoHeight
-          rows={filteredRows}
-          columns={columns}
-          loading={loading}
-          getRowId={(row) => row.id}
-          paginationModel={paginationModel}
-          onPaginationModelChange={setPaginationModel}
-          pageSizeOptions={[10, 25, 50, 100]}
-          disableRowSelectionOnClick
-          onRowDoubleClick={(params) => {
-            const row = params.row as BillRow;
-            const targetBill =
-              row?.normalizedBillNumber ||
-              row?.billNumber?.replace(/\D+/g, "") ||
-              "";
-            const rawName = row?.raw?.Name ?? "";
-            if (!targetBill) {
-              return;
-            }
-            navigate(`/bill?number=${encodeURIComponent(targetBill)}&name=${encodeURIComponent(rawName)}`);
+        aria-label="bill chamber filter"
+      >
+        {tabs.map((tabOption) => (
+          <ToggleButton
+            key={tabOption.value}
+            value={tabOption.value}
+            aria-label={tabOption.label}
+          >
+            {tabOption.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <TextField
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          size="small"
+          placeholder="Search"
+          sx={{ width: 220 }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchOutlined />
+              </InputAdornment>
+            )
           }}
-          showToolbar={true}
-          slots={{ toolbar: CustomToolbar }}
         />
-      </CardContent>
-    </Card>
-  </>
+        <Tooltip title="Open Bill Search">
+          <IconButton color="primary" onClick={handleOpenBillSearch}>
+            <ExpandAltOutlined />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Refresh">
+          <IconButton color="primary" onClick={fetchBills}>
+            <ReloadOutlined />
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </Toolbar>
+  );
+
+  return (
+    <Box sx={{ marginTop: 1 }}>
+      <Toolbar>
+        <Typography variant="h3" component="div" sx={{ flexGrow: 1 }}>
+          Bills
+        </Typography>
+      </Toolbar>
+      <DataGrid
+        apiRef={apiRef}
+        autoHeight
+        rows={filteredRows}
+        columns={columns}
+        loading={loading}
+        getRowId={(row) => row.id}
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
+        pageSizeOptions={[10, 25, 50, 100]}
+        disableRowSelectionOnClick
+        onRowDoubleClick={(params) => handleRowDoubleClick(params.row as BillRow)}
+        slots={{ toolbar: BillsToolbar }}
+      />
+    </Box>
   );
 };
 

--- a/src/pages/extra-pages/CommitteePage/MembersGrid.tsx
+++ b/src/pages/extra-pages/CommitteePage/MembersGrid.tsx
@@ -1,5 +1,6 @@
+import { CopyOutlined } from "@ant-design/icons";
 import { PageInfo } from "@digitalaidseattle/supabase";
-import { Link } from "@mui/material";
+import { Box, Button, Link, Snackbar } from "@mui/material";
 import { DataGrid, GridColDef, useGridApiRef } from "@mui/x-data-grid";
 import { useEffect, useState } from "react";
 import { LegislatureService } from "../../../api/legislatureService";
@@ -18,6 +19,7 @@ const MembersGrid = (props: { agency: string, committeeName: string }) => {
     rows: [],
     totalRowCount: 0,
   });
+  const [copyMessage, setCopyMessage] = useState("");
 
   // const [agency, setAgency] = useState<string>("");
   // const [committeeName, setCommitteeName] = useState<string>("");
@@ -65,6 +67,26 @@ const MembersGrid = (props: { agency: string, committeeName: string }) => {
       .catch(error => {
         console.error('Error invoking function:', error);
       });
+  }
+
+  async function copyEmails() {
+    const emails = pageInfo.rows
+      .map((row) => row.Email)
+      .filter((email) => typeof email === "string" && email.trim().length > 0)
+      .join(", ");
+
+    if (!emails) {
+      setCopyMessage("No emails found.");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(emails);
+      setCopyMessage("All committee emails copied.");
+    } catch (error) {
+      console.error("Failed to copy emails:", error);
+      setCopyMessage("Copy failed. Please try again.");
+    }
   }
 
   const getColumns = (): GridColDef[] => {
@@ -123,15 +145,33 @@ const MembersGrid = (props: { agency: string, committeeName: string }) => {
   };
 
 return (
-  <DataGrid
-    getRowId={(row) => row.Id}
-    apiRef={apiRef}
-    rows={pageInfo.rows}
-    columns={columns}
-    paginationModel={paginationModel}
-    onPaginationModelChange={setPaginationModel}
-    pageSizeOptions={[10, 25, 50, 100]}
-  />
+  <Box>
+    <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
+      <Button
+        variant="text"
+        color="primary"
+        startIcon={<CopyOutlined />}
+        onClick={copyEmails}
+      >
+        Copy all emails
+      </Button>
+    </Box>
+    <DataGrid
+      getRowId={(row) => row.Id}
+      apiRef={apiRef}
+      rows={pageInfo.rows}
+      columns={columns}
+      paginationModel={paginationModel}
+      onPaginationModelChange={setPaginationModel}
+      pageSizeOptions={[10, 25, 50, 100]}
+    />
+    <Snackbar
+      open={Boolean(copyMessage)}
+      autoHideDuration={2000}
+      onClose={() => setCopyMessage("")}
+      message={copyMessage}
+    />
+  </Box>
 )
 }
 

--- a/src/pages/extra-pages/CommitteePage/MembersGrid.tsx
+++ b/src/pages/extra-pages/CommitteePage/MembersGrid.tsx
@@ -1,6 +1,7 @@
 import { CopyOutlined } from "@ant-design/icons";
+import { useNotifications } from "@digitalaidseattle/core";
 import { PageInfo } from "@digitalaidseattle/supabase";
-import { Box, Button, Link, Snackbar } from "@mui/material";
+import { Box, Button, Link } from "@mui/material";
 import { DataGrid, GridColDef, useGridApiRef } from "@mui/x-data-grid";
 import { useEffect, useState } from "react";
 import { LegislatureService } from "../../../api/legislatureService";
@@ -9,6 +10,7 @@ const PAGE_SIZE = 25;
 
 const MembersGrid = (props: { agency: string, committeeName: string }) => {
   const apiRef = useGridApiRef();
+  const notifications = useNotifications();
   const [paginationModel, setPaginationModel] = useState({
     page: 0,
     pageSize: PAGE_SIZE,
@@ -19,7 +21,6 @@ const MembersGrid = (props: { agency: string, committeeName: string }) => {
     rows: [],
     totalRowCount: 0,
   });
-  const [copyMessage, setCopyMessage] = useState("");
 
   // const [agency, setAgency] = useState<string>("");
   // const [committeeName, setCommitteeName] = useState<string>("");
@@ -33,7 +34,7 @@ const MembersGrid = (props: { agency: string, committeeName: string }) => {
     if (props.committeeName && props.agency) {
       refresh()
     }
-  }, [props]);
+  },[props]);
 
 
   // function exportData() {
@@ -76,16 +77,16 @@ const MembersGrid = (props: { agency: string, committeeName: string }) => {
       .join(", ");
 
     if (!emails) {
-      setCopyMessage("No emails found.");
+      notifications.warn("No emails found.");
       return;
     }
 
     try {
       await navigator.clipboard.writeText(emails);
-      setCopyMessage("All committee emails copied.");
+      notifications.success("All committee emails copied.");
     } catch (error) {
       console.error("Failed to copy emails:", error);
-      setCopyMessage("Copy failed. Please try again.");
+      notifications.error("Copy failed. Please try again.");
     }
   }
 
@@ -164,12 +165,6 @@ return (
       paginationModel={paginationModel}
       onPaginationModelChange={setPaginationModel}
       pageSizeOptions={[10, 25, 50, 100]}
-    />
-    <Snackbar
-      open={Boolean(copyMessage)}
-      autoHideDuration={2000}
-      onClose={() => setCopyMessage("")}
-      message={copyMessage}
     />
   </Box>
 )

--- a/src/utils/bills.ts
+++ b/src/utils/bills.ts
@@ -4,255 +4,273 @@ import type {
   LegislativeDocument
 } from "../api/bill";
 
-function mapLegislativeDocumentToBillRow(
-  bill: LegislativeDocument,
-  index: number
-): BillRow | undefined {
-  const billIdentifier = stringFallback([bill.Name]);
-  const fallbackIdentifier = stringFallback([
-    bill.Title,
-    bill.ShortDescription,
-    bill.Description
-  ]);
-  const billNumber = billIdentifier || fallbackIdentifier;
-  const normalizedBillNumber = extractBillNumber(billIdentifier ?? fallbackIdentifier, bill) ?? "";
-
-  if (!billNumber) {
-    return undefined;
-  }
-
-  const chamber = inferChamber(bill);
-  const committee = deriveCommittee(bill);
-  const title = stringFallback([
-    bill.Title,
-    bill.LongTitle,
-    bill.Description,
-    bill.ShortDescription
-  ]);
-  const historyLine = latestHistoryLine(bill);
-  const status = stringFallback([
-    bill.Status,
-    bill.CurrentStatus,
-    historyLine?.Text,
-    historyLine?.Description,
-    historyLine?.HistoryText
-  ]);
-  const history = formatHistory(historyLine);
-  const { label: latestDocumentLabel, url: latestDocumentUrl } =
-    deriveDocumentLink(bill);
-
-  return {
-    id: [billNumber, bill.Biennium ?? index].join("-"),
-    billNumber: displayValue(billNumber),
-    normalizedBillNumber,
-    committee: displayValue(committee),
-    title: displayValue(title),
-    status: displayValue(status),
-    history: displayValue(history),
-    latestDocumentLabel: displayValue(latestDocumentLabel),
-    latestDocumentUrl,
-    chamber,
-    raw: bill
-  };
-}
-
-function sanitizeBillUrl(
-  url: string,
-  bill?: LegislativeDocument
-): string {
-  if (!url) {
-    return "";
-  }
-
-  try {
-    const parsed = new URL(url);
-    const original = parsed.searchParams.get("BillNumber");
-    const replacement = extractBillNumber(original, bill);
-    if (replacement && replacement !== original) {
-      parsed.searchParams.set("BillNumber", replacement);
-      return parsed.toString();
-    }
-    return url;
-  } catch (_error) {
-    const replacement = extractBillNumber(undefined, bill);
-    if (!replacement) {
-      return url;
-    }
-    return url.replace(/BillNumber=[^&]+/, `BillNumber=${replacement}`);
-  }
-}
-
-function extractBillNumber(
-  candidate?: string | null,
-  bill?: LegislativeDocument
-): string | undefined {
-  const possibilities: Array<string | undefined | null> = [
-    candidate,
-    bill?.Name,
-    bill?.Title,
-    bill?.Description
-  ];
-
-  for (const value of possibilities) {
-    if (typeof value !== "string") {
-      continue;
-    }
-    const digitsOnly = value.replace(/\D+/g, "");
-    if (digitsOnly.length > 0) {
-      return digitsOnly;
-    }
-  }
-  return undefined;
-}
-
-function stringFallback(candidates: Array<string | undefined | null>) {
-  for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate.trim();
-    }
-  }
-  return "";
-}
-
-function deriveCommittee(bill: LegislativeDocument) {
-  const committeeCandidate = stringFallback([
-    Array.isArray(bill.CommitteeNames?.CommitteeName)
-      ? bill.CommitteeNames?.CommitteeName?.[0]
-      : typeof bill.CommitteeNames?.CommitteeName === "string"
-      ? bill.CommitteeNames.CommitteeName
-      : undefined,
-    bill.CommitteeName,
-    bill.OriginatingAgency,
-    bill.Agency
-  ]);
-
-  return committeeCandidate;
-}
-
-function inferChamber(bill: LegislativeDocument): BillRow["chamber"] {
-  const textual = [
-    bill.Chamber,
-    bill.OriginatingAgency,
-    bill.Agency
-  ]
-    .map((value) =>
-      typeof value === "string" ? value.toLowerCase() : undefined
-    )
-    .filter(Boolean) as string[];
-
-  if (textual.some((value) => value.includes("joint"))) {
-    return "Joint";
-  }
-  if (textual.some((value) => value.includes("house"))) {
-    return "House";
-  }
-  if (textual.some((value) => value.includes("senate"))) {
-    return "Senate";
-  }
-
-  const name = (bill.Name ?? "").toUpperCase();
-  if (name.startsWith("HB")) {
-    return "House";
-  }
-  if (["HJR", "HJM", "HCR"].some((prefix) => name.startsWith(prefix))) {
-    return "Joint";
-  }
-
-  if (name.startsWith("SB")) {
-    return "Senate";
-  }
-  if (["SJR", "SJM", "SCR"].some((prefix) => name.startsWith(prefix))) {
-    return "Joint";
-  }
-  return "Unknown";
-}
-
-function latestHistoryLine(
-  bill: LegislativeDocument
-): DocumentHistoryLine | undefined {
-  const historyNode = bill.DocumentHistory?.DocumentHistoryLine;
-  if (!historyNode) {
-    return undefined;
-  }
-  if (Array.isArray(historyNode)) {
-    return historyNode[0];
-  }
-  return historyNode;
-}
-
-function formatHistory(historyLine: ReturnType<typeof latestHistoryLine>) {
-  if (!historyLine) {
-    return "";
-  }
-  const possibleDate =
-    historyLine.ActionDate ??
-    historyLine.Date ??
-    historyLine.HistoryDate;
-  const possibleText =
-    historyLine.Text ??
-    historyLine.Description ??
-    historyLine.HistoryText;
-
-  const formattedDate = formatDate(possibleDate);
-
-  return [formattedDate, possibleText].filter(Boolean).join(" ");
-}
-
-function formatDate(raw?: string) {
-  if (!raw) {
-    return "";
-  }
-  const date = new Date(raw);
-  if (Number.isNaN(date.getTime())) {
-    return raw;
-  }
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric"
-  }).format(date);
-}
-
-function deriveDocumentLink(bill: LegislativeDocument) {
-  const url =
-    bill.Url ??
-    bill.Hyperlink ??
-    bill.SourceUrl ??
-    "";
-  const sanitizedUrl = sanitizeBillUrl(url, bill);
-  const label = stringFallback([
-    bill.Description,
-    bill.DocumentTypeDescription,
-    bill.DocumentType,
-    bill.DocumentTypeAbbreviation,
-    sanitizedUrl ? "View document" : ""
-  ]);
-
-  return {
-    label: label || (sanitizedUrl ? "View document" : ""),
-    url: sanitizedUrl || undefined
-  };
-}
-
-function displayValue(value: string) {
-  return value && value.trim().length > 0 ? value : "—";
-}
-
-function summarizeSponsors(bill: LegislativeDocument): string {
-  const sponsorField = bill?.Sponsors;
-  if (!sponsorField) {
-    return "";
-  }
-  if (typeof sponsorField === "string") {
-    return sponsorField;
-  }
-  return Array.isArray(sponsorField) ? sponsorField.join(", ") : "";
-}
-
-export {
-  mapLegislativeDocumentToBillRow,
-  sanitizeBillUrl,
-  deriveDocumentLink,
-  inferChamber,
-  summarizeSponsors,
-  extractBillNumber
+type BillFilterOptions = {
+  tab: string;
+  query: string;
 };
+
+class BillsService {
+  static mapLegislativeDocumentToBillRow(
+    bill: LegislativeDocument,
+    index: number
+  ): BillRow | undefined {
+    const billIdentifier = BillsService.stringFallback([bill.Name]);
+    const fallbackIdentifier = BillsService.stringFallback([
+      bill.Title,
+      bill.ShortDescription,
+      bill.Description
+    ]);
+    const billNumber = billIdentifier || fallbackIdentifier;
+    const normalizedBillNumber =
+      BillsService.extractBillNumber(billIdentifier ?? fallbackIdentifier, bill) ?? "";
+
+    if (!billNumber) {
+      return undefined;
+    }
+
+    const chamber = BillsService.inferChamber(bill);
+    const committee = BillsService.deriveCommittee(bill);
+    const title = BillsService.stringFallback([
+      bill.Title,
+      bill.LongTitle,
+      bill.Description,
+      bill.ShortDescription
+    ]);
+    const historyLine = BillsService.latestHistoryLine(bill);
+    const status = BillsService.stringFallback([
+      bill.Status,
+      bill.CurrentStatus,
+      historyLine?.Text,
+      historyLine?.Description,
+      historyLine?.HistoryText
+    ]);
+    const history = BillsService.formatHistory(historyLine);
+    const { label: latestDocumentLabel, url: latestDocumentUrl } =
+      BillsService.deriveDocumentLink(bill);
+
+    return {
+      id: [billNumber, bill.Biennium ?? index].join("-"),
+      billNumber: BillsService.displayValue(billNumber),
+      normalizedBillNumber,
+      committee: BillsService.displayValue(committee),
+      title: BillsService.displayValue(title),
+      status: BillsService.displayValue(status),
+      history: BillsService.displayValue(history),
+      latestDocumentLabel: BillsService.displayValue(latestDocumentLabel),
+      latestDocumentUrl,
+      chamber,
+      raw: bill
+    };
+  }
+
+  static buildFilterPredicate({ tab, query }: BillFilterOptions) {
+    const loweredQuery = query.trim().toLowerCase();
+    return (row: BillRow) => {
+      const matchesTab = tab === "all" ? true : row.chamber.toLowerCase() === tab;
+      if (!matchesTab) {
+        return false;
+      }
+      if (!loweredQuery) {
+        return true;
+      }
+      const haystack = [
+        row.billNumber,
+        row.title,
+        row.committee,
+        row.status,
+        row.history,
+        row.latestDocumentLabel
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(loweredQuery);
+    };
+  }
+
+  static sanitizeBillUrl(url: string, bill?: LegislativeDocument): string {
+    if (!url) {
+      return "";
+    }
+
+    try {
+      const parsed = new URL(url);
+      const original = parsed.searchParams.get("BillNumber");
+      const replacement = BillsService.extractBillNumber(original, bill);
+      if (replacement && replacement !== original) {
+        parsed.searchParams.set("BillNumber", replacement);
+        return parsed.toString();
+      }
+      return url;
+    } catch (_error) {
+      const replacement = BillsService.extractBillNumber(undefined, bill);
+      if (!replacement) {
+        return url;
+      }
+      return url.replace(/BillNumber=[^&]+/, `BillNumber=${replacement}`);
+    }
+  }
+
+  static extractBillNumber(
+    candidate?: string | null,
+    bill?: LegislativeDocument
+  ): string | undefined {
+    const possibilities: Array<string | undefined | null> = [
+      candidate,
+      bill?.Name,
+      bill?.Title,
+      bill?.Description
+    ];
+
+    for (const value of possibilities) {
+      if (typeof value !== "string") {
+        continue;
+      }
+      const digitsOnly = value.replace(/\D+/g, "");
+      if (digitsOnly.length > 0) {
+        return digitsOnly;
+      }
+    }
+    return undefined;
+  }
+
+  static summarizeSponsors(bill: LegislativeDocument): string {
+    const sponsorField = bill?.Sponsors;
+    if (!sponsorField) {
+      return "";
+    }
+    if (typeof sponsorField === "string") {
+      return sponsorField;
+    }
+    return Array.isArray(sponsorField) ? sponsorField.join(", ") : "";
+  }
+
+  private static stringFallback(candidates: Array<string | undefined | null>) {
+    for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate.trim().length > 0) {
+        return candidate.trim();
+      }
+    }
+    return "";
+  }
+
+  private static deriveCommittee(bill: LegislativeDocument) {
+    const committeeCandidate = BillsService.stringFallback([
+      Array.isArray(bill.CommitteeNames?.CommitteeName)
+        ? bill.CommitteeNames?.CommitteeName?.[0]
+        : typeof bill.CommitteeNames?.CommitteeName === "string"
+        ? bill.CommitteeNames.CommitteeName
+        : undefined,
+      bill.CommitteeName,
+      bill.OriginatingAgency,
+      bill.Agency
+    ]);
+
+    return committeeCandidate;
+  }
+
+  private static inferChamber(bill: LegislativeDocument): BillRow["chamber"] {
+    const textual = [
+      bill.Chamber,
+      bill.OriginatingAgency,
+      bill.Agency
+    ]
+      .map((value) =>
+        typeof value === "string" ? value.toLowerCase() : undefined
+      )
+      .filter(Boolean) as string[];
+
+    if (textual.some((value) => value.includes("joint"))) {
+      return "Joint";
+    }
+    if (textual.some((value) => value.includes("house"))) {
+      return "House";
+    }
+    if (textual.some((value) => value.includes("senate"))) {
+      return "Senate";
+    }
+
+    const name = (bill.Name ?? "").toUpperCase();
+    if (name.startsWith("HB")) {
+      return "House";
+    }
+    if (["HJR", "HJM", "HCR"].some((prefix) => name.startsWith(prefix))) {
+      return "Joint";
+    }
+
+    if (name.startsWith("SB")) {
+      return "Senate";
+    }
+    if (["SJR", "SJM", "SCR"].some((prefix) => name.startsWith(prefix))) {
+      return "Joint";
+    }
+    return "Unknown";
+  }
+
+  private static latestHistoryLine(
+    bill: LegislativeDocument
+  ): DocumentHistoryLine | undefined {
+    const historyNode = bill.DocumentHistory?.DocumentHistoryLine;
+    if (!historyNode) {
+      return undefined;
+    }
+    if (Array.isArray(historyNode)) {
+      return historyNode[0];
+    }
+    return historyNode;
+  }
+
+  private static formatHistory(
+    historyLine: ReturnType<typeof BillsService.latestHistoryLine>
+  ) {
+    if (!historyLine) {
+      return "";
+    }
+    const possibleDate =
+      historyLine.ActionDate ??
+      historyLine.Date ??
+      historyLine.HistoryDate;
+    const possibleText =
+      historyLine.Text ??
+      historyLine.Description ??
+      historyLine.HistoryText;
+
+    const formattedDate = BillsService.formatDate(possibleDate);
+
+    return [formattedDate, possibleText].filter(Boolean).join(" ");
+  }
+
+  private static formatDate(raw?: string) {
+    if (!raw) {
+      return "";
+    }
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) {
+      return raw;
+    }
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric"
+    }).format(date);
+  }
+
+  private static deriveDocumentLink(bill: LegislativeDocument) {
+    const url =
+      bill.Url ??
+      bill.Hyperlink ??
+      bill.SourceUrl ??
+      "";
+    const sanitizedUrl = BillsService.sanitizeBillUrl(url, bill);
+    const label = sanitizedUrl ? "View document" : "";
+
+    return {
+      label,
+      url: sanitizedUrl || undefined
+    };
+  }
+
+  private static displayValue(value: string) {
+    return value && value.trim().length > 0 ? value : "—";
+  }
+}
+
+export { BillsService };

--- a/src/utils/bills.ts
+++ b/src/utils/bills.ts
@@ -4,257 +4,273 @@ import type {
   LegislativeDocument
 } from "../api/bill";
 
-function mapLegislativeDocumentToBillRow(
-  bill: LegislativeDocument,
-  index: number
-): BillRow | undefined {
-  const billIdentifier = stringFallback([bill.Name]);
-  const fallbackIdentifier = stringFallback([
-    bill.Title,
-    bill.ShortDescription,
-    bill.Description
-  ]);
-  const billNumber = billIdentifier || fallbackIdentifier;
-  const normalizedBillNumber = extractBillNumber(billIdentifier ?? fallbackIdentifier, bill) ?? "";
+type BillFilterOptions = {
+  tab: string;
+  query: string;
+};
 
-  if (!billNumber) {
+class BillsService {
+  static mapLegislativeDocumentToBillRow(
+    bill: LegislativeDocument,
+    index: number
+  ): BillRow | undefined {
+    const billIdentifier = BillsService.stringFallback([bill.Name]);
+    const fallbackIdentifier = BillsService.stringFallback([
+      bill.Title,
+      bill.ShortDescription,
+      bill.Description
+    ]);
+    const billNumber = billIdentifier || fallbackIdentifier;
+    const normalizedBillNumber =
+      BillsService.extractBillNumber(billIdentifier ?? fallbackIdentifier, bill) ?? "";
+
+    if (!billNumber) {
+      return undefined;
+    }
+
+    const chamber = BillsService.inferChamber(bill);
+    const committee = BillsService.deriveCommittee(bill);
+    const title = BillsService.stringFallback([
+      bill.Title,
+      bill.LongTitle,
+      bill.Description,
+      bill.ShortDescription
+    ]);
+    const historyLine = BillsService.latestHistoryLine(bill);
+    const status = BillsService.stringFallback([
+      bill.Status,
+      bill.CurrentStatus,
+      historyLine?.Text,
+      historyLine?.Description,
+      historyLine?.HistoryText
+    ]);
+    const history = BillsService.formatHistory(historyLine);
+    const { label: latestDocumentLabel, url: latestDocumentUrl } =
+      BillsService.deriveDocumentLink(bill);
+
+    return {
+      id: [billNumber, bill.Biennium ?? index].join("-"),
+      billNumber: BillsService.displayValue(billNumber),
+      normalizedBillNumber,
+      committee: BillsService.displayValue(committee),
+      title: BillsService.displayValue(title),
+      status: BillsService.displayValue(status),
+      history: BillsService.displayValue(history),
+      latestDocumentLabel: BillsService.displayValue(latestDocumentLabel),
+      latestDocumentUrl,
+      chamber,
+      raw: bill
+    };
+  }
+
+  static buildFilterPredicate({ tab, query }: BillFilterOptions) {
+    const loweredQuery = query.trim().toLowerCase();
+    return (row: BillRow) => {
+      const matchesTab = tab === "all" ? true : row.chamber.toLowerCase() === tab;
+      if (!matchesTab) {
+        return false;
+      }
+      if (!loweredQuery) {
+        return true;
+      }
+      const haystack = [
+        row.billNumber,
+        row.title,
+        row.committee,
+        row.status,
+        row.history,
+        row.latestDocumentLabel
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(loweredQuery);
+    };
+  }
+
+  static sanitizeBillUrl(url: string, bill?: LegislativeDocument): string {
+    if (!url) {
+      return "";
+    }
+
+    try {
+      const parsed = new URL(url);
+      const original = parsed.searchParams.get("BillNumber");
+      const replacement = BillsService.extractBillNumber(original, bill);
+      if (replacement && replacement !== original) {
+        parsed.searchParams.set("BillNumber", replacement);
+        return parsed.toString();
+      }
+      return url;
+    } catch (_error) {
+      const replacement = BillsService.extractBillNumber(undefined, bill);
+      if (!replacement) {
+        return url;
+      }
+      return url.replace(/BillNumber=[^&]+/, `BillNumber=${replacement}`);
+    }
+  }
+
+  static extractBillNumber(
+    candidate?: string | null,
+    bill?: LegislativeDocument
+  ): string | undefined {
+    const possibilities: Array<string | undefined | null> = [
+      candidate,
+      bill?.Name,
+      bill?.Title,
+      bill?.Description
+    ];
+
+    for (const value of possibilities) {
+      if (typeof value !== "string") {
+        continue;
+      }
+      const digitsOnly = value.replace(/\D+/g, "");
+      if (digitsOnly.length > 0) {
+        return digitsOnly;
+      }
+    }
     return undefined;
   }
 
-  const chamber = inferChamber(bill);
-  const committee = deriveCommittee(bill);
-  const title = stringFallback([
-    bill.Title,
-    bill.LongTitle,
-    bill.Description,
-    bill.ShortDescription
-  ]);
-  const historyLine = latestHistoryLine(bill);
-  const status = stringFallback([
-    bill.Status,
-    bill.CurrentStatus,
-    historyLine?.Text,
-    historyLine?.Description,
-    historyLine?.HistoryText
-  ]);
-  const history = formatHistory(historyLine);
-  const { label: latestDocumentLabel, url: latestDocumentUrl } =
-    deriveDocumentLink(bill);
+  static summarizeSponsors(bill: LegislativeDocument): string {
+    const sponsorField = bill?.Sponsors;
+    if (!sponsorField) {
+      return "";
+    }
+    if (typeof sponsorField === "string") {
+      return sponsorField;
+    }
+    return Array.isArray(sponsorField) ? sponsorField.join(", ") : "";
+  }
 
-  return {
-    id: [billNumber, bill.Biennium ?? index].join("-"),
-    billNumber: displayValue(billNumber),
-    normalizedBillNumber,
-    committee: displayValue(committee),
-    title: displayValue(title),
-    status: displayValue(status),
-    history: displayValue(history),
-    latestDocumentLabel: displayValue(latestDocumentLabel),
-    latestDocumentUrl,
-    chamber,
-    raw: bill
-  };
-}
-
-function sanitizeBillUrl(
-  url: string,
-  bill?: LegislativeDocument
-): string {
-  if (!url) {
+  private static stringFallback(candidates: Array<string | undefined | null>) {
+    for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate.trim().length > 0) {
+        return candidate.trim();
+      }
+    }
     return "";
   }
 
-  try {
-    const parsed = new URL(url);
-    const original = parsed.searchParams.get("BillNumber");
-    const replacement = extractBillNumber(original, bill);
-    if (replacement && replacement !== original) {
-      parsed.searchParams.set("BillNumber", replacement);
-      return parsed.toString();
-    }
-    return url;
-  } catch (_error) {
-    const replacement = extractBillNumber(undefined, bill);
-    if (!replacement) {
-      return url;
-    }
-    return url.replace(/BillNumber=[^&]+/, `BillNumber=${replacement}`);
-  }
-}
-
-function extractBillNumber(
-  candidate?: string | null,
-  bill?: LegislativeDocument
-): string | undefined {
-  const possibilities: Array<string | undefined | null> = [
-    candidate,
-    bill?.Name,
-    bill?.Title,
-    bill?.Description
-  ];
-
-  return possibilities
-    .filter(poss => poss)
-    .map(poss => String(poss).replace(/\D+/g, ""))
-    .find(poss => poss.length > 0)
-
-  // for (const value of possibilities) {
-  //   if (typeof value !== "string") {
-  //     continue;
-  //   }
-  //   const digitsOnly = value.replace(/\D+/g, "");
-  //   if (digitsOnly.length > 0) {
-  //     return digitsOnly;
-  //   }
-  // }
-  // return undefined;
-}
-
-function stringFallback(candidates: Array<string | undefined | null>) {
-  const found = candidates
-    .find(candidate => typeof candidate === "string" && candidate.trim().length > 0);
-  return found ? found.trim() : "";
-
-  // for (const candidate of candidates) {
-  //   if (typeof candidate === "string" && candidate.trim().length > 0) {
-  //     return candidate.trim();
-  //   }
-  // }
-  // return "";
-}
-
-function deriveCommittee(bill: LegislativeDocument) {
-  const committeeCandidate = stringFallback([
-    Array.isArray(bill.CommitteeNames?.CommitteeName)
-      ? bill.CommitteeNames?.CommitteeName?.[0]
-      : typeof bill.CommitteeNames?.CommitteeName === "string"
+  private static deriveCommittee(bill: LegislativeDocument) {
+    const committeeCandidate = BillsService.stringFallback([
+      Array.isArray(bill.CommitteeNames?.CommitteeName)
+        ? bill.CommitteeNames?.CommitteeName?.[0]
+        : typeof bill.CommitteeNames?.CommitteeName === "string"
         ? bill.CommitteeNames.CommitteeName
         : undefined,
-    bill.CommitteeName,
-    bill.OriginatingAgency,
-    bill.Agency
-  ]);
+      bill.CommitteeName,
+      bill.OriginatingAgency,
+      bill.Agency
+    ]);
 
-  return committeeCandidate;
+    return committeeCandidate;
+  }
+
+  private static inferChamber(bill: LegislativeDocument): BillRow["chamber"] {
+    const textual = [
+      bill.Chamber,
+      bill.OriginatingAgency,
+      bill.Agency
+    ]
+      .map((value) =>
+        typeof value === "string" ? value.toLowerCase() : undefined
+      )
+      .filter(Boolean) as string[];
+
+    if (textual.some((value) => value.includes("joint"))) {
+      return "Joint";
+    }
+    if (textual.some((value) => value.includes("house"))) {
+      return "House";
+    }
+    if (textual.some((value) => value.includes("senate"))) {
+      return "Senate";
+    }
+
+    const name = (bill.Name ?? "").toUpperCase();
+    if (name.startsWith("HB")) {
+      return "House";
+    }
+    if (["HJR", "HJM", "HCR"].some((prefix) => name.startsWith(prefix))) {
+      return "Joint";
+    }
+
+    if (name.startsWith("SB")) {
+      return "Senate";
+    }
+    if (["SJR", "SJM", "SCR"].some((prefix) => name.startsWith(prefix))) {
+      return "Joint";
+    }
+    return "Unknown";
+  }
+
+  private static latestHistoryLine(
+    bill: LegislativeDocument
+  ): DocumentHistoryLine | undefined {
+    const historyNode = bill.DocumentHistory?.DocumentHistoryLine;
+    if (!historyNode) {
+      return undefined;
+    }
+    if (Array.isArray(historyNode)) {
+      return historyNode[0];
+    }
+    return historyNode;
+  }
+
+  private static formatHistory(
+    historyLine: ReturnType<typeof BillsService.latestHistoryLine>
+  ) {
+    if (!historyLine) {
+      return "";
+    }
+    const possibleDate =
+      historyLine.ActionDate ??
+      historyLine.Date ??
+      historyLine.HistoryDate;
+    const possibleText =
+      historyLine.Text ??
+      historyLine.Description ??
+      historyLine.HistoryText;
+
+    const formattedDate = BillsService.formatDate(possibleDate);
+
+    return [formattedDate, possibleText].filter(Boolean).join(" ");
+  }
+
+  private static formatDate(raw?: string) {
+    if (!raw) {
+      return "";
+    }
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) {
+      return raw;
+    }
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric"
+    }).format(date);
+  }
+
+  private static deriveDocumentLink(bill: LegislativeDocument) {
+    const url =
+      bill.Url ??
+      bill.Hyperlink ??
+      bill.SourceUrl ??
+      "";
+    const sanitizedUrl = BillsService.sanitizeBillUrl(url, bill);
+    const label = sanitizedUrl ? "View document" : "";
+
+    return {
+      label,
+      url: sanitizedUrl || undefined
+    };
+  }
+
+  private static displayValue(value: string) {
+    return value && value.trim().length > 0 ? value : "—";
+  }
 }
 
-function inferChamber(bill: LegislativeDocument): BillRow["chamber"] {
-  const textual = [
-    bill.Chamber,
-    bill.OriginatingAgency,
-    bill.Agency
-  ]
-    .map((value) =>
-      typeof value === "string" ? value.toLowerCase() : undefined
-    )
-    .filter(Boolean) as string[];
-
-  if (textual.some((value) => value.includes("joint"))) {
-    return "Joint";
-  }
-  if (textual.some((value) => value.includes("house"))) {
-    return "House";
-  }
-  if (textual.some((value) => value.includes("senate"))) {
-    return "Senate";
-  }
-
-  const name = (bill.Name ?? "").toUpperCase();
-  if (name.startsWith("HB")) {
-    return "House";
-  }
-  if (["HJR", "HJM", "HCR"].some((prefix) => name.startsWith(prefix))) {
-    return "Joint";
-  }
-
-  if (name.startsWith("SB")) {
-    return "Senate";
-  }
-  if (["SJR", "SJM", "SCR"].some((prefix) => name.startsWith(prefix))) {
-    return "Joint";
-  }
-  return "Unknown";
-}
-
-function latestHistoryLine(
-  bill: LegislativeDocument
-): DocumentHistoryLine | undefined {
-  const historyNode = bill.DocumentHistory?.DocumentHistoryLine;
-  if (!historyNode) {
-    return undefined;
-  }
-  if (Array.isArray(historyNode)) {
-    return historyNode[0];
-  }
-  return historyNode;
-}
-
-function formatHistory(historyLine: ReturnType<typeof latestHistoryLine>) {
-  if (!historyLine) {
-    return "";
-  }
-  const possibleDate =
-    historyLine.ActionDate ??
-    historyLine.Date ??
-    historyLine.HistoryDate;
-  const possibleText =
-    historyLine.Text ??
-    historyLine.Description ??
-    historyLine.HistoryText;
-
-  const formattedDate = formatDate(possibleDate);
-
-  return [formattedDate, possibleText].filter(Boolean).join(" ");
-}
-
-function formatDate(raw?: string) {
-  if (!raw) {
-    return "";
-  }
-  const date = new Date(raw);
-  if (Number.isNaN(date.getTime())) {
-    return raw;
-  }
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric"
-  }).format(date);
-}
-
-function deriveDocumentLink(bill: LegislativeDocument) {
-  const url =
-    bill.Url ??
-    bill.Hyperlink ??
-    bill.SourceUrl ??
-    "";
-  const sanitizedUrl = sanitizeBillUrl(url, bill);
-  
-  return {
-    label:  "View document",
-    url: sanitizedUrl || undefined
-  };
-}
-
-function displayValue(value: string) {
-  return value && value.trim().length > 0 ? value : "—";
-}
-
-function summarizeSponsors(bill: LegislativeDocument): string {
-  const sponsorField = bill.Sponsors;
-  if (!sponsorField) {
-    return "";
-  }
-  if (typeof sponsorField === "string") {
-    return sponsorField;
-  }
-  return Array.isArray(sponsorField) ? sponsorField.join(", ") : "";
-}
-
-export {
-  mapLegislativeDocumentToBillRow,
-  sanitizeBillUrl,
-  deriveDocumentLink,
-  inferChamber,
-  summarizeSponsors,
-  extractBillNumber
-};
+export { BillsService };

--- a/src/utils/bills.ts
+++ b/src/utils/bills.ts
@@ -168,7 +168,7 @@ class BillsService {
     return committeeCandidate;
   }
 
-  private static inferChamber(bill: LegislativeDocument): BillRow["chamber"] {
+  static inferChamber(bill: LegislativeDocument): BillRow["chamber"] {
     const textual = [
       bill.Chamber,
       bill.OriginatingAgency,
@@ -253,7 +253,7 @@ class BillsService {
     }).format(date);
   }
 
-  private static deriveDocumentLink(bill: LegislativeDocument) {
+  static deriveDocumentLink(bill: LegislativeDocument) {
     const url =
       bill.Url ??
       bill.Hyperlink ??
@@ -273,4 +273,21 @@ class BillsService {
   }
 }
 
-export { BillsService };
+const deriveDocumentLink = (bill: LegislativeDocument) =>
+  BillsService.deriveDocumentLink(bill);
+const extractBillNumber = (
+  candidate?: string | null,
+  bill?: LegislativeDocument
+) => BillsService.extractBillNumber(candidate, bill);
+const inferChamber = (bill: LegislativeDocument) =>
+  BillsService.inferChamber(bill);
+const summarizeSponsors = (bill: LegislativeDocument) =>
+  BillsService.summarizeSponsors(bill);
+
+export {
+  BillsService,
+  deriveDocumentLink,
+  extractBillNumber,
+  inferChamber,
+  summarizeSponsors
+};


### PR DESCRIPTION
## Description

_Give a brief context and description of the code change. Highlight anything you want reviewers to pay attention to._

_The PR should have enough information so someone coming in fresh gets a sense of what's going on, but the details of the overall project can be documented on project.digitalaidseattle.org_

## What type of PR is this? (check all applicable)

- [✓ ] Refactor
- [ ✓] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

_Link user story from projects.digitalaidseattle.org_

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Install deps and launch the app: npm install && npm run dev.
Go to http://localhost:3000/committees, select a committee, and click on "Copy All Emails" to copy the email addresses.



<img width="900" height="1153" alt="Screenshot 2026-02-03 at 11 01 29 PM" src="https://github.com/user-attachments/assets/a8faf293-d53f-40d8-9a34-c44101d959a4" />


For Refactoring 
Visit http://localhost:3000/bills and confirm the table renders, tabs/search control filters, and each row’s “Latest Available Documents” link opens a URL